### PR TITLE
wp-rest php7.0 compatible

### DIFF
--- a/wp-rest/Controller/Rest.php
+++ b/wp-rest/Controller/Rest.php
@@ -152,8 +152,8 @@ class Rest extends Base {
 
 		$args = $request->get_params();
 
-		// destructure entity and action
-		[ 'entity' => $entity, 'action' => $action ] = $args;
+		$entity = $args['entity'];
+		$action = $args['action'];
 
 		// unset unnecessary args
 		unset( $args['entity'], $args['action'], $args['key'], $args['api_key'] );


### PR DESCRIPTION
Overview
----------------------------------------
Makes the Civi WP REST API php 7.0 compatible.

Before
----------------------------------------
It requires php7.1+

After
----------------------------------------
Works with php 7.0+

Comments
----------------------------------------
Removes the use of array destructuring.
