### PR TITLE
handle timestamps mismatched system error, CRM-12523/CRM-18062/CRM-19115

### DIFF
--- a/wp-rest/Plugin.php
+++ b/wp-rest/Plugin.php
@@ -35,6 +35,8 @@ class Plugin {
 
 		add_filter( 'rest_pre_dispatch', [ $this, 'bootstrap_civi' ], 10, 3 );
 
+		add_filter( 'rest_post_dispatch',  [ $this, 'maybe_reset_wp_timezone' ], 10, 3);
+
 	}
 
 	/**
@@ -48,7 +50,13 @@ class Plugin {
 	 */
 	public function bootstrap_civi( $result, $server, $request ) {
 
-		if ( false !== strpos( $request->get_route(), 'civicrm' ) ) civi_wp()->initialize();
+		if ( false !== strpos( $request->get_route(), 'civicrm' ) ) {
+
+			$this->maybe_set_user_timezone( $request );
+
+			civi_wp()->initialize();
+
+		}
 
 		return $result;
 
@@ -119,6 +127,66 @@ class Plugin {
 		 * @since 0.1
 		 */
 		do_action( 'civi_wp_rest/plugin/rest_routes_registered' );
+
+	}
+
+	/**
+	 * Sets the timezone to the users timezone when
+	 * calling the civicrm/v3/rest endpoint.
+	 *
+	 * @since 0.1
+	 * @param WP_REST_Request $request The request
+	 */
+	private function maybe_set_user_timezone( $request ) {
+
+		if ( $request->get_route() != '/civicrm/v3/rest' ) return;
+
+		$timezones = [
+			'wp_timezone' => date_default_timezone_get(),
+			'user_timezone' => get_option( 'timezone_string', false )
+		];
+
+		// filter timezones
+		add_filter( 'civi_wp_rest/plugin/timezones', function() use ( $timezones ) {
+
+			return $timezones;
+
+		} );
+
+		if ( empty( $timezones['user_timezone'] ) ) return;
+
+		/**
+		 * CRM-12523
+		 * CRM-18062
+		 * CRM-19115
+		 */
+		date_default_timezone_set( $timezones['user_timezone'] );
+		\CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
+
+	}
+
+	/**
+	 * Resets the timezone to the original WP
+	 * timezone after calling the civicrm/v3/rest endpoint.
+	 *
+	 * @since 0.1
+	 * @param mixed $result
+	 * @param WP_REST_Server $server REST server instance
+	 * @param WP_REST_Request $request The request
+	 * @return mixed $result
+	 */
+	public function maybe_reset_wp_timezone( $result, $server, $request ) {
+
+		if ( $request->get_route() != '/civicrm/v3/rest' ) return;
+
+		$timezones = apply_filters( 'civi_wp_rest/plugin/timezones', null );
+
+		if ( empty( $timezones['wp_timezone'] ) ) return $result;
+
+		// reset wp timezone
+		date_default_timezone_set( $timezones['wp_timezone'] );
+
+		return $result;
 
 	}
 

--- a/wp-rest/Plugin.php
+++ b/wp-rest/Plugin.php
@@ -177,7 +177,7 @@ class Plugin {
 	 */
 	public function maybe_reset_wp_timezone( $result, $server, $request ) {
 
-		if ( $request->get_route() != '/civicrm/v3/rest' ) return;
+		if ( $request->get_route() != '/civicrm/v3/rest' ) return $result;
 
 		$timezones = apply_filters( 'civi_wp_rest/plugin/timezones', null );
 


### PR DESCRIPTION
Overview
----------------------------------------
Prevents `System.check` API returning a false error that my PHP and MySQL timestamps are mismatched.

Before
----------------------------------------
`System.check` calls return an error on environments with mismatched PHP-MySQL timezones.
```
Timestamps reported by MySQL (eg \"2019-08-23 11:06\") and PHP (eg \"2019-08-23 10:06\" ) are mismatched.
```

After
----------------------------------------
`System.check` does not return a false error.