### PR TITLE
Standardise error responses for the rest endpoint

### DIFF
--- a/wp-rest/.editorconfig
+++ b/wp-rest/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+# Not top-most EditorConfig file
+root = false
+
+# Tab indentation
+[*.php]
+indent_style = tab
+indent_size = 4

--- a/wp-rest/Controller/Base.php
+++ b/wp-rest/Controller/Base.php
@@ -88,13 +88,19 @@ abstract class Base extends \WP_REST_Controller implements Endpoint_Interface {
 	 * Wrapper for WP_Error.
 	 *
 	 * @since 0.1
-	 * @param string $message
+	 * @param string|\CiviCRM_API3_Exception $error
 	 * @param mixed $data Error data
 	 * @return WP_Error $error
 	 */
-	protected function civi_rest_error( $message, $data = [] ) {
+	protected function civi_rest_error( $error, $data = [] ) {
 
-		return new \WP_Error( 'civicrm_rest_api_error', $message, empty( $data ) ? [ 'status' => $this->authorization_status_code() ] : $data );
+		if ( $error instanceof \CiviCRM_API3_Exception ) {
+
+			return $error->getExtraParams();
+
+		}
+
+		return new \WP_Error( 'civicrm_rest_api_error', $error, empty( $data ) ? [ 'status' => $this->authorization_status_code() ] : $data );
 
 	}
 

--- a/wp-rest/Controller/Rest.php
+++ b/wp-rest/Controller/Rest.php
@@ -78,7 +78,7 @@ class Rest extends Base {
 
 		} catch ( \CiviCRM_API3_Exception $e ) {
 
-			return $this->civi_rest_error( $e->getMessage() );
+			$items = $this->civi_rest_error( $e );
 
 		}
 


### PR DESCRIPTION
Overview
----------------------------------------
* Standardise error responses for the `rest` endpoint to be event with `extern/rest.php`, instead of returning a `WP_Error` we return the API Exception's `extraParams`.
* Adds `.editorconfig` file (seemed a bit overkill to open another PR just for that, but le me know if it's needed).

Before
----------------------------------------
An error (`WP_Error`) response would look like:

``` json
{
	"code": "civicrm_rest_api_error",
	"message": "Mandatory key(s) missing from params array: contact_type",
	"data": {
		"status": 403
	}
}
```

After
----------------------------------------
An error (`CiviCRM_API3_Exception`) looks like:

```
{
	"fields": [
		"contact_type"
	],
	"error_code": "mandatory_missing",
	"entity": "Contact",
	"action": "create",
	"is_error": 1,
	"error_message": "Mandatory key(s) missing from params array: contact_type"
}
```


Comments
----------------------------------------
For reference see mecachisenros/civicrm-wp-rest/issues/5