### PR TITLE
Prevent clash with CiviCRM WP REST plugin

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -512,8 +512,10 @@ class CiviCRM_For_WordPress {
     include_once CIVICRM_PLUGIN_DIR . 'includes/civicrm.basepage.php';
     $this->basepage = new CiviCRM_For_WordPress_Basepage;
 
-    // Include REST API autoloader class
-    require_once( CIVICRM_PLUGIN_DIR . 'wp-rest/Autoloader.php' );
+    if ( ! class_exists( 'CiviCRM_WP_REST\Autoloader' ) ) {
+      // Include REST API autoloader class
+      require_once( CIVICRM_PLUGIN_DIR . 'wp-rest/Autoloader.php' );
+    }
 
   }
 
@@ -627,11 +629,15 @@ class CiviCRM_For_WordPress {
     // Register hooks for clean URLs.
     $this->register_hooks_clean_urls();
 
-    // Set up REST API.
-    CiviCRM_WP_REST\Autoloader::add_source( $source_path = trailingslashit( CIVICRM_PLUGIN_DIR . 'wp-rest' ) );
+    if ( ! class_exists( 'CiviCRM_WP_REST\Plugin' ) ) {
 
-    // Init REST API.
-    new CiviCRM_WP_REST\Plugin;
+      // Set up REST API.
+      CiviCRM_WP_REST\Autoloader::add_source( $source_path = trailingslashit( CIVICRM_PLUGIN_DIR . 'wp-rest' ) );
+
+      // Init REST API.
+      new CiviCRM_WP_REST\Plugin;
+
+    }
 
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Prevents a fatal error `cannot redeclare class CiviCRM_WP_REST\Autoloader` if the [CiviCRM WP REST](https://github.com/mecachisenros/civicrm-wp-rest) plugin is activated.

Before
----------------------------------------
Fatal error `cannot redeclare class CiviCRM_WP_REST\Autoloader`

After
----------------------------------------
Both plugins can coexist.

