### PR TITLE
Adds the 'civi_wp_rest/controller/rest/permissions_check' filter

### DIFF
--- a/wp-rest/Controller/Base.php
+++ b/wp-rest/Controller/Base.php
@@ -88,7 +88,7 @@ abstract class Base extends \WP_REST_Controller implements Endpoint_Interface {
 	 * Wrapper for WP_Error.
 	 *
 	 * @since 0.1
-	 * @param string|\CiviCRM_API3_Exception $error
+	 * @param string|\CiviCRM_API3_Exception|\WP_Error $error
 	 * @param mixed $data Error data
 	 * @return WP_Error $error
 	 */
@@ -97,6 +97,10 @@ abstract class Base extends \WP_REST_Controller implements Endpoint_Interface {
 		if ( $error instanceof \CiviCRM_API3_Exception ) {
 
 			return $error->getExtraParams();
+
+		} elseif ( $error instanceof \WP_Error ) {
+
+			return $error;
 
 		}
 


### PR DESCRIPTION
Overview
----------------------------------------
Adds the `add civi_wp_rest/controller/rest/permissions_check` filter allowing to bypass or replace CiviCRM's API authentication (api_key and site_key) with a custom one for the `rest` endpoint.

Before
----------------------------------------
Authentication couldn't be replaced or bypassed.

After
----------------------------------------
Authentication could be replaced or bypassed:

``` php
add_filter( 'civi_wp_rest/controller/rest/permissions_check', function( $grant_auth, \WP_REST_Request $request ) {

	/**
	 * You can return the following types:
	 *
	 * 1. true (bool), for granting access
	 * 2. false (bool), for denying access
	 * 3. 'Some error message' (string), for throwing an error
	 * 4. ['some', 'error', 'data'] (array), for throwing an error
	 * 5. new WP_Error( 'api_error', 'Some error message', ['some', 'error', 'data'] ) (WP_Error instance), for throwing an error
	 *
	 * 6. Default to null, CiviCRM's authentication method (site_key and api_key)
	 */

	// theoretical example assuming a nonce based authentication
	$nonce = $request->get_param( 'nonce' );

	// fallback to default auth if no nonce provided
	if ( empty( $nonce ) ) return $grant_auth;

	// fallback to default auth if invalid nonce
	if ( ! wp_verify_nonce( $nonce, 'some action' ) ) return $grant_auth;

	// nonce verified, grant access
	return true;

}, 10, 2 );
```

