### PR TITLE
Adds support for 'hook_civicrm_alterExternUrl' and adds a 'civi_wp_rest/plugin/replace_mailing_tracking_urls' filter 

### DIFF
--- a/wp-rest/Plugin.php
+++ b/wp-rest/Plugin.php
@@ -69,8 +69,19 @@ class Plugin {
 	 */
 	private function setup_objects() {
 
-		if ( CIVICRM_WP_REST_REPLACE_MAILING_TRACKING ) {
+		/**
+ 		 * Filter to replace the mailing tracking URLs.
+ 		 *
+ 		 * @since 0.1
+ 		 * @param bool $replace_mailing_tracking_urls
+ 		 */
+ 		$replace_mailing_tracking_urls = apply_filters( 'civi_wp_rest/plugin/replace_mailing_tracking_urls', false );
 
+ 		// keep CIVICRM_WP_REST_REPLACE_MAILING_TRACKING for backwards compatibility
+ 		if (
+ 			$replace_mailing_tracking_urls
+ 			|| ( defined( 'CIVICRM_WP_REST_REPLACE_MAILING_TRACKING' ) && CIVICRM_WP_REST_REPLACE_MAILING_TRACKING )
+ 		) {
 			// register mailing hooks
 			$mailing_hooks = ( new Mailing_Hooks )->register_hooks();
 


### PR DESCRIPTION
Overview
----------------------------------------
Uses the `hook_civicrm_alterExternUrl` to alter mailing tracking URLs if available. 

Adds the `civi_wp_rest/plugin/replace_mailing_tracking_urls` filter for enabling/disabling tracking url replacement while keeping compatibility with the `CIVICRM_WP_REST_REPLACE_MAILING_TRACKING` constant.

Before
----------------------------------------
* Altering the mailing tracking URLs is done via `phpQuery` and `preg_replace()`.

* To enable mailing tracking URLs replacement one must declare a `CIVICRM_WP_REST_REPLACE_MAILING_TRACKING` constant set to `true`.

After
----------------------------------------
* Altering the mailing tracking URLs is done via `hook_civicrm_alterExternUrl ` if available, falling back to `phpQuery` and `preg_replace()`.

* To enable tracking URLs replacement should be done via the new hook instead:

``` php 
add_filter( 'civi_wp_rest/plugin/replace_mailing_tracking_urls', '__return_true' );
```
