### PR TITLE
Minor fixes

### DIFF
--- a/wp-rest/Autoloader.php
+++ b/wp-rest/Autoloader.php
@@ -93,9 +93,9 @@ class Autoloader {
 	 */
 	private function autoload( $class_name ) {
 
-		if ( false === strpos( $class_name, $this->namespace ) ) return;
-
 		$parts = explode( '\\', $class_name );
+
+		if ( $this->namespace !== $parts[0] ) return;
 
 		// remove namespace and join class path
 		$class_path = str_replace( '_', '-', implode( DIRECTORY_SEPARATOR, array_slice( $parts, 1 ) ) );

--- a/wp-rest/Controller/Rest.php
+++ b/wp-rest/Controller/Rest.php
@@ -480,7 +480,7 @@ class Rest extends Base {
 
 			// If this fails, get it from config.
 			if ( $domain_id === 0 ) {
-				$domain_id = CRM_Core_Config::domainID();
+				$domain_id = \CRM_Core_Config::domainID();
 			}
 
 			// Call API.

--- a/wp-rest/Controller/Url.php
+++ b/wp-rest/Controller/Url.php
@@ -124,6 +124,8 @@ class Url extends Base {
 
 		}
 
+		if ( strpos( $url, 'mailto' ) ) $url = strstr( $url, 'mailto' );
+
 		return apply_filters( 'civi_wp_rest/controller/url/parsed_url', $url, $params );
 
 	}


### PR DESCRIPTION
Overview
----------------------------------------

* missing global namespace calling `CRM_Core_Config::domainID()`
* malformed email (`mailto`) URLs
* ensures we only try to autoload `CiviCRM_WP_REST` namespace